### PR TITLE
Fix handling of suffix (NOTE: merge manually: micron changed)

### DIFF
--- a/EngineeringNotationFormatter/YouNeedTheseFiles/EngNotation.c
+++ b/EngineeringNotationFormatter/YouNeedTheseFiles/EngNotation.c
@@ -42,7 +42,7 @@
 #define NUM_PREFIX 17
 static char *prefix[NUM_PREFIX] = {
   "y", "z", "a", "f",
-  "p", "n", "Âµ", "m",
+  "p", "n", "µ", "m",
   "",  "k", "M", "G",
   "T", "P", "E", "Z",
   "Y"
@@ -154,14 +154,15 @@ static char *eng2exp(const char *val)
 		if(!isdigit(c)) {
 			for(int i=0; i<NUM_PREFIX; ++i) {
 				const char *p = prefix[i];
+				if ( 0 == strlen(p) ) continue; // MM: skip empty suffix
 				size_t plen = strlen(p);
 				size_t strt = len - plen;
 				const char *tst = &val[strt];
 				if(!strcmp(tst, p)) {
 					// need 4+null for new string
 					tmp = (char *)malloc(strt + 4 + 1);
-					strncpy(tmp, val, strt);
-					tmp[strt] = '\0';
+					strncpy( tmp, val, strt-1 );    // MM: remove space
+					tmp[strt-1] = '\0';             // MM: remove space
 					strcat(tmp, reversePrefix[i]);
 					break;
 				}


### PR DESCRIPTION
There's likely an oversight in function `static char *eng2exp(const char *val)`.

The function does not cater for the empty suffix halfway the table `prefix` and it doesn't remove the space between the number and the appended e-power. This results in not searching the positive powers and prevents the appended power to play a role in the conversion.

```
prompt>gcc -Wall -std=c99 -o Test_EngNotation.orig.exe Test_EngNotation.c EngNotation.orig.c && Test_EngNotation.orig
'1.23 k'
ERROR   x: 1.23e-006    g:      1.23    inp:'1.23 ╡'    out:'1.23 '
ERROR   x: 1.23e-005    g:      12.3    inp:'12.3 ╡'    out:'12.3 '
ERROR   x:  0.000123    g:       123    inp:'123 ╡'     out:'123 '
ERROR   x:   0.00123    g:      1.23    inp:'1.23 m'    out:'1.23 '
ERROR   x:    0.0123    g:      12.3    inp:'12.3 m'    out:'12.3 '
ERROR   x:     0.123    g:       123    inp:'123 m'     out:'123 '
OK      x:      1.23    g:      1.23    inp:'1.23 '     out:'1.23 '
OK      x:      12.3    g:      12.3    inp:'12.3 '     out:'12.3 '
OK      x:       123    g:       123    inp:'123 '      out:'123 '
ERROR   x:      1230    g:      1.23    inp:'1.23 k'    out:'1.23 '
ERROR   x:     12300    g:      12.3    inp:'12.3 k'    out:'12.3 '
ERROR   x:    123000    g:       123    inp:'123 k'     out:'123 '

prompt>gcc -Wall -std=c99 -o Test_EngNotation.exe Test_EngNotation.c EngNotation.c && Test_EngNotation
'1.23 k'
OK      x: 1.23e-006    g: 1.23e-006    inp:'1.23 ╡'    out:'1.23 ╡'
OK      x: 1.23e-005    g: 1.23e-005    inp:'12.3 ╡'    out:'12.3 ╡'
OK      x:  0.000123    g:  0.000123    inp:'123 ╡'     out:'123 ╡'
OK      x:   0.00123    g:   0.00123    inp:'1.23 m'    out:'1.23 m'
OK      x:    0.0123    g:    0.0123    inp:'12.3 m'    out:'12.3 m'
OK      x:     0.123    g:     0.123    inp:'123 m'     out:'123 m'
OK      x:      1.23    g:      1.23    inp:'1.23 '     out:'1.23 '
OK      x:      12.3    g:      12.3    inp:'12.3 '     out:'12.3 '
OK      x:       123    g:       123    inp:'123 '      out:'123 '
OK      x:      1230    g:      1230    inp:'1.23 k'    out:'1.23 k'
OK      x:     12300    g:     12300    inp:'12.3 k'    out:'12.3 k'
OK      x:    123000    g:    123000    inp:'123 k'     out:'123 k'
```

Test_EngNotation.c:

``` C

#include "EngNotation.h"

#include <float.h>
#include <math.h>
#include <stdio.h>
#include <string.h>

double max( double const a, double const b ) { return a >= b ? a : b; }

bool approx( double const a, double const b )
{
    const double scale = 1.0;
    const double epsilon = 100 * DBL_EPSILON;

    return fabs(a - b) < epsilon * (scale + (max)( fabs(a), fabs(b) ) );
}

int main()
{
    fprintf( stdout, "'%s'\n", dbl2eng( 1234, 3, false) );

    for ( int i = -6; i < +6; ++i )
    {
        const double x = 1.23 * pow(10,i);

        char text_inp[20];
        char text_out[20];

        strcpy( text_inp, dbl2eng( x, 3, false ) );
        const double  g = eng2dbl( text_inp );
        strcpy( text_out, dbl2eng( g, 3, false ) );

        char const * const result = approx( x, g ) ? "OK":"ERROR";

        fprintf( stdout, "%-8sx:%10g\tg:%10g\tinp:'%s'\tout:'%s'\n", result, x, g, text_inp, text_out );
    }
}

// gcc -Wall -std=c99 -o Test_EngNotation.exe Test_EngNotation.c EngNotation.c && Test_EngNotation
// gcc -Wall -std=c99 -o Test_EngNotation.orig.exe Test_EngNotation.c EngNotation.orig.c && Test_EngNotation.orig
```
